### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ O Conversor de Texto para Fala oferece uma interface intuitiva para transformar 
 - Controle de velocidade da fala
 - Contagem automática de palavras e caracteres
 - Interface responsiva para uso em dispositivos móveis e desktop
+- Botão para alternância entre modo claro e escuro
 
 ## Tecnologias Utilizadas
 
@@ -47,6 +48,7 @@ Para melhor experiência e acesso às vozes Google de alta qualidade, recomenda-
 4. Ajuste a velocidade da fala conforme necessário
 5. Clique em "Reproduzir" para ouvir o texto
 6. Para interromper a reprodução, clique em "Parar"
+7. Utilize o botão "Modo Escuro" no cabeçalho para alternar o tema
 
 ## Desenvolvimento
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div class="container">
         <header>
             <h1>Conversor de Texto para Fala</h1>
+            <button id="dark-mode-toggle" class="btn secondary-btn">Modo Escuro</button>
         </header>
 
         <main>

--- a/script.js
+++ b/script.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const speedControl = document.getElementById('speed-control');
     const speedValue = document.getElementById('speed-value');
     const playBtn = document.getElementById('play-btn');
+    const darkModeToggle = document.getElementById('dark-mode-toggle');
     const statusMessage = document.getElementById('status-message');
     const wordCount = document.getElementById('word-count');
     const charCount = document.getElementById('char-count');
@@ -41,6 +42,7 @@ AGI pode pensar e resolver muitos problemas como uma pessoa.`
     textInput.addEventListener('input', updateTextStats);
     speedControl.addEventListener('input', updateSpeedValue);
     playBtn.addEventListener('click', handlePlayStop);
+    darkModeToggle.addEventListener('click', toggleDarkMode);
     
     // Adicionar event listener para mudança de idioma
     languageSelect.addEventListener('change', handleLanguageChange);
@@ -105,6 +107,15 @@ AGI pode pensar e resolver muitos problemas como uma pessoa.`
     function updateSpeedValue() {
         const speed = speedControl.value;
         speedValue.textContent = `${speed}x`;
+    }
+
+    function toggleDarkMode() {
+        document.body.classList.toggle('dark-mode');
+        if (document.body.classList.contains('dark-mode')) {
+            darkModeToggle.textContent = 'Modo Claro';
+        } else {
+            darkModeToggle.textContent = 'Modo Escuro';
+        }
     }
 
     // Função para lidar com o botão de reprodução/parada

--- a/style.css
+++ b/style.css
@@ -20,13 +20,15 @@ body {
 
 /* Cabeçalho */
 header {
-    text-align: center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     margin-bottom: 30px;
 }
 
 header h1 {
     color: #3498db;
-    margin-bottom: 5px;
+    margin-bottom: 0;
 }
 
 header p {
@@ -195,4 +197,35 @@ footer p {
     .btn {
         width: 100%;
     }
+}
+
+/* Modo escuro */
+body.dark-mode {
+    background-color: #121212;
+    color: #f0f0f0;
+}
+
+body.dark-mode .controls-container {
+    background-color: #1e1e1e;
+}
+
+body.dark-mode textarea {
+    background-color: #1e1e1e;
+    border-color: #555;
+    color: #f0f0f0;
+}
+
+body.dark-mode select,
+body.dark-mode input[type="range"] {
+    background-color: #2c2c2c;
+    color: #f0f0f0;
+}
+
+body.dark-mode .primary-btn {
+    background-color: #2980b9;
+}
+
+body.dark-mode .secondary-btn {
+    background-color: #444;
+    color: #f0f0f0;
 }


### PR DESCRIPTION
## Summary
- add new button in header to toggle dark mode
- style header layout and define dark-mode styles
- handle dark mode toggle via JavaScript
- document dark mode feature and usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f5b4d4c3c8323aa6e5c049ec132f9