### PR TITLE
Atualiza botão do modo para ícone fixo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ O Conversor de Texto para Fala oferece uma interface intuitiva para transformar 
 - Controle de velocidade da fala
 - Contagem automática de palavras e caracteres
 - Interface responsiva para uso em dispositivos móveis e desktop
-- Botão para alternância entre modo claro e escuro
+- Ícone no canto superior direito para alternar entre modo claro e escuro
 
 ## Tecnologias Utilizadas
 
@@ -48,7 +48,7 @@ Para melhor experiência e acesso às vozes Google de alta qualidade, recomenda-
 4. Ajuste a velocidade da fala conforme necessário
 5. Clique em "Reproduzir" para ouvir o texto
 6. Para interromper a reprodução, clique em "Parar"
-7. Utilize o botão "Modo Escuro" no cabeçalho para alternar o tema
+7. Use o ícone no canto superior direito para alternar o tema
 
 ## Desenvolvimento
 

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     <div class="container">
         <header>
             <h1>Conversor de Texto para Fala</h1>
-            <button id="dark-mode-toggle" class="btn secondary-btn">Modo Escuro</button>
         </header>
+        <button id="dark-mode-toggle" class="mode-toggle-btn" aria-label="Alternar modo">🌙</button>
 
         <main>
             <div class="text-input-container">

--- a/script.js
+++ b/script.js
@@ -37,6 +37,13 @@ AGI pode pensar e resolver muitos problemas como uma pessoa.`
     // Inicialização
     checkBrowserSupport();
     loadVoices();
+
+    // Definir ícone inicial do modo
+    if (document.body.classList.contains('dark-mode')) {
+        darkModeToggle.textContent = '☀️';
+    } else {
+        darkModeToggle.textContent = '🌙';
+    }
     
     // Event listeners
     textInput.addEventListener('input', updateTextStats);
@@ -112,9 +119,9 @@ AGI pode pensar e resolver muitos problemas como uma pessoa.`
     function toggleDarkMode() {
         document.body.classList.toggle('dark-mode');
         if (document.body.classList.contains('dark-mode')) {
-            darkModeToggle.textContent = 'Modo Claro';
+            darkModeToggle.textContent = '☀️';
         } else {
-            darkModeToggle.textContent = 'Modo Escuro';
+            darkModeToggle.textContent = '🌙';
         }
     }
 

--- a/style.css
+++ b/style.css
@@ -156,6 +156,29 @@ input[type="range"] {
     background-color: #d0d0d0;
 }
 
+/* Botão de alternância de modo */
+.mode-toggle-btn {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background-color: #e0e0e0;
+    color: #333;
+    cursor: pointer;
+    font-size: 1.2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+body.dark-mode .mode-toggle-btn {
+    background-color: #444;
+    color: #f0f0f0;
+}
+
 /* Mensagem de status */
 .status-message {
     min-height: 20px;


### PR DESCRIPTION
## Summary
- troca o botão de texto por ícone de sol/lua para alternância de tema
- posiciona o botão fixo no canto superior direito
- ajusta script para atualizar ícone conforme o modo
- documenta novo posicionamento no README

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_684f5d6737d08323b2ec7d40e0b605f6