### PR TITLE
Enable permanent dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ O Conversor de Texto para Fala oferece uma interface intuitiva para transformar 
 - Controle de velocidade da fala
 - Contagem automática de palavras e caracteres
 - Interface responsiva para uso em dispositivos móveis e desktop
-- Ícone no canto superior direito para alternar entre modo claro e escuro
 
 ## Tecnologias Utilizadas
 
@@ -48,7 +47,7 @@ Para melhor experiência e acesso às vozes Google de alta qualidade, recomenda-
 4. Ajuste a velocidade da fala conforme necessário
 5. Clique em "Reproduzir" para ouvir o texto
 6. Para interromper a reprodução, clique em "Parar"
-7. Use o ícone no canto superior direito para alternar o tema
+7. A interface utiliza sempre o tema escuro
 
 ## Desenvolvimento
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
         <header>
             <h1>Conversor de Texto para Fala</h1>
         </header>
-        <button id="dark-mode-toggle" class="mode-toggle-btn" aria-label="Alternar modo">🌙</button>
 
         <main>
             <div class="text-input-container">

--- a/script.js
+++ b/script.js
@@ -11,7 +11,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const speedControl = document.getElementById('speed-control');
     const speedValue = document.getElementById('speed-value');
     const playBtn = document.getElementById('play-btn');
-    const darkModeToggle = document.getElementById('dark-mode-toggle');
     const statusMessage = document.getElementById('status-message');
     const wordCount = document.getElementById('word-count');
     const charCount = document.getElementById('char-count');
@@ -38,18 +37,11 @@ AGI pode pensar e resolver muitos problemas como uma pessoa.`
     checkBrowserSupport();
     loadVoices();
 
-    // Definir ícone inicial do modo
-    if (document.body.classList.contains('dark-mode')) {
-        darkModeToggle.textContent = '☀️';
-    } else {
-        darkModeToggle.textContent = '🌙';
-    }
     
     // Event listeners
     textInput.addEventListener('input', updateTextStats);
     speedControl.addEventListener('input', updateSpeedValue);
     playBtn.addEventListener('click', handlePlayStop);
-    darkModeToggle.addEventListener('click', toggleDarkMode);
     
     // Adicionar event listener para mudança de idioma
     languageSelect.addEventListener('change', handleLanguageChange);
@@ -116,14 +108,6 @@ AGI pode pensar e resolver muitos problemas como uma pessoa.`
         speedValue.textContent = `${speed}x`;
     }
 
-    function toggleDarkMode() {
-        document.body.classList.toggle('dark-mode');
-        if (document.body.classList.contains('dark-mode')) {
-            darkModeToggle.textContent = '☀️';
-        } else {
-            darkModeToggle.textContent = '🌙';
-        }
-    }
 
     // Função para lidar com o botão de reprodução/parada
     function handlePlayStop() {

--- a/style.css
+++ b/style.css
@@ -7,8 +7,8 @@
 }
 
 body {
-    background-color: #ffffff;
-    color: #333333;
+    background-color: #121212;
+    color: #f0f0f0;
     line-height: 1.6;
 }
 
@@ -45,11 +45,13 @@ textarea {
     width: 100%;
     min-height: 200px;
     padding: 15px;
-    border: 1px solid #ddd;
+    border: 1px solid #555;
     border-radius: 5px;
     font-size: 1rem;
     resize: vertical;
     transition: border 0.3s;
+    background-color: #1e1e1e;
+    color: #f0f0f0;
 }
 
 textarea:focus {
@@ -61,13 +63,13 @@ textarea:focus {
 .text-stats {
     text-align: right;
     font-size: 0.8rem;
-    color: #666;
+    color: #cccccc;
     margin-top: 5px;
 }
 
 /* Controles */
 .controls-container {
-    background-color: #f5f5f5;
+    background-color: #1e1e1e;
     padding: 20px;
     border-radius: 5px;
     margin-bottom: 20px;
@@ -90,9 +92,10 @@ textarea:focus {
 
 select {
     padding: 8px 12px;
-    border: 1px solid #ddd;
+    border: 1px solid #555;
     border-radius: 4px;
-    background-color: white;
+    background-color: #2c2c2c;
+    color: #f0f0f0;
     flex-grow: 1;
     cursor: pointer;
 }
@@ -107,6 +110,8 @@ input[type="range"] {
     flex-grow: 1;
     margin-right: 10px;
     cursor: pointer;
+    background-color: #2c2c2c;
+    color: #f0f0f0;
 }
 
 #speed-value {
@@ -148,42 +153,20 @@ input[type="range"] {
 }
 
 .secondary-btn {
-    background-color: #e0e0e0;
-    color: #333;
-}
-
-.secondary-btn:hover {
-    background-color: #d0d0d0;
-}
-
-/* Botão de alternância de modo */
-.mode-toggle-btn {
-    position: fixed;
-    top: 20px;
-    right: 20px;
-    width: 40px;
-    height: 40px;
-    border: none;
-    border-radius: 50%;
-    background-color: #e0e0e0;
-    color: #333;
-    cursor: pointer;
-    font-size: 1.2rem;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-body.dark-mode .mode-toggle-btn {
     background-color: #444;
     color: #f0f0f0;
 }
+
+.secondary-btn:hover {
+    background-color: #555;
+}
+
 
 /* Mensagem de status */
 .status-message {
     min-height: 20px;
     text-align: center;
-    color: #666;
+    color: #cccccc;
     font-size: 0.9rem;
     margin-bottom: 20px;
 }
@@ -193,8 +176,8 @@ footer {
     text-align: center;
     margin-top: 30px;
     padding-top: 20px;
-    border-top: 1px solid #eee;
-    color: #666;
+    border-top: 1px solid #333;
+    color: #cccccc;
     font-size: 0.8rem;
 }
 
@@ -222,33 +205,3 @@ footer p {
     }
 }
 
-/* Modo escuro */
-body.dark-mode {
-    background-color: #121212;
-    color: #f0f0f0;
-}
-
-body.dark-mode .controls-container {
-    background-color: #1e1e1e;
-}
-
-body.dark-mode textarea {
-    background-color: #1e1e1e;
-    border-color: #555;
-    color: #f0f0f0;
-}
-
-body.dark-mode select,
-body.dark-mode input[type="range"] {
-    background-color: #2c2c2c;
-    color: #f0f0f0;
-}
-
-body.dark-mode .primary-btn {
-    background-color: #2980b9;
-}
-
-body.dark-mode .secondary-btn {
-    background-color: #444;
-    color: #f0f0f0;
-}


### PR DESCRIPTION
## Summary
- set dark colors as base styles
- remove dark mode toggle button and related JavaScript
- clean up README instructions for theme

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f5f762ba08323a7d38dddb92a240f